### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache:
     - $HOME/.m2
 scala:
   - 2.11.11
+jdk:
+  - openjdk8
 script:
   - mvn scalastyle:check
   - mvn test


### PR DESCRIPTION
Thi PR fixes the [Travis CI](https://travis-ci.com/SANSA-Stack/SANSA-DataLake) build due to the Java version (Travis CI runs on Java 11 by default).

Best regards,